### PR TITLE
Remove (Intel) label from unity path

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -115,7 +115,8 @@ async function postInstall() {
 
 async function findUnity(unityHubPath, unityVersion) {
     let unityPath = '';
-    const output = await executeHub(unityHubPath, `editors --installed`);
+    let output = await executeHub(unityHubPath, `editors --installed`);
+    output = output.replace("(Intel)", "");
     const match = output.match(new RegExp(`${unityVersion} , installed at (.+)`));
     if (match) {
         unityPath = match[1];


### PR DESCRIPTION
Possible fix for #5
In new version of Unity Hub on macs path to unity contains (Intel) label. Looks like it is unnecessary. In this PR I just removed this label