### PR TITLE
 Fix for 2021.3.6f1,2021.3.7f1 on macOS machines and self-runners

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -119,9 +119,18 @@ async function findUnity(unityHubPath, unityVersion) {
     const match = output.match(new RegExp(`${unityVersion} , installed at (.+)`));
     if (match) {
         unityPath = match[1];
-        if (unityPath && process.platform === 'darwin') {
-            unityPath += '/Contents/MacOS/Unity';
-        }
+    }
+    const match_intel = output.match(new RegExp(`${unityVersion} (Intel), installed at (.+)`));
+    if (match_intel) {
+        unityPath = match_intel[1];
+    }
+    /*const match_macos_intel = output.match(new RegExp(`${unityVersion} (Silicon), installed at (.+)`));
+    if (match_macos_intel) {
+        unityPath = match_macos_intel[1];
+    }*/
+
+    if (unityPath && process.platform === 'darwin') {
+        unityPath += '/Contents/MacOS/Unity';
     }
     return unityPath;
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -121,7 +121,7 @@ async function findUnity(unityHubPath, unityVersion) {
         unityPath = match[1];
     }
     //2021.3.7f1 (Intel), installed at /Applications/Unity/Hub/Editor/2021.3.7f1/Unity.app
-    const match_intel = output.match(new RegExp(`${unityVersion} (Intel), installed at (.+)`));
+    const match_intel = output.match(new RegExp(`${unityVersion} \(Intel\), installed at (.+)`));
     if (match_intel) {
         unityPath = match_intel[1];
     }

--- a/src/setup.js
+++ b/src/setup.js
@@ -116,22 +116,12 @@ async function postInstall() {
 async function findUnity(unityHubPath, unityVersion) {
     let unityPath = '';
     const output = await executeHub(unityHubPath, `editors --installed`);
-    const match = output.match(new RegExp(`${unityVersion} , installed at (.+)`));
+    const match = output.match(new RegExp(`${unityVersion}.+, installed at (.+)`));
     if (match) {
         unityPath = match[1];
-    }
-    //2021.3.7f1 (Intel), installed at /Applications/Unity/Hub/Editor/2021.3.7f1/Unity.app
-    const match_intel = output.match(new RegExp(`${unityVersion} \(Intel\), installed at (.+)`));
-    if (match_intel) {
-        unityPath = match_intel[1];
-    }
-    /*const match_macos_intel = output.match(new RegExp(`${unityVersion} (Silicon), installed at (.+)`));
-    if (match_macos_intel) {
-        unityPath = match_macos_intel[1];
-    }*/
-
-    if (unityPath && process.platform === 'darwin') {
-        unityPath += '/Contents/MacOS/Unity';
+        if (unityPath && process.platform === 'darwin') {
+            unityPath += '/Contents/MacOS/Unity';
+        }
     }
     return unityPath;
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -12,7 +12,7 @@ async function run() {
         const unityModulesChild = getInputAsBool('unity-modules-child');
         const installPath = core.getInput('install-path');
         const projectPath = core.getInput('project-path');
-        const self_runner = core.getInput('self_runner');
+        let self_runner = core.getInput('self_runner');
 
         if(!self_runner) {
             self_runner = false

--- a/src/setup.js
+++ b/src/setup.js
@@ -83,7 +83,7 @@ async function installUnityHub() {
     return unityHubPath;
 }
 
-async function installUnityEditor(unityHubPath, installPath, unityVersion, unityVersionChangeset,githubMachine) {
+async function installUnityEditor(unityHubPath, installPath, unityVersion, unityVersionChangeset,self_runner) {
     let unityPath = await findUnity(unityHubPath, unityVersion);
     if (!unityPath) {
         if (installPath) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -12,6 +12,11 @@ async function run() {
         const unityModulesChild = getInputAsBool('unity-modules-child');
         const installPath = core.getInput('install-path');
         const projectPath = core.getInput('project-path');
+        const self_runner = core.getInput('self_runner');
+
+        if(!self_runner) {
+            self_runner = false
+        }
 
         if (!unityVersion) {
             [unityVersion, unityVersionChangeset] = await findProjectVersion(projectPath);
@@ -19,11 +24,11 @@ async function run() {
             unityVersionChangeset = await findVersionChangeset(unityVersion);
         }
         const unityHubPath = await installUnityHub();
-        const unityPath = await installUnityEditor(unityHubPath, installPath, unityVersion, unityVersionChangeset);
+        const unityPath = await installUnityEditor(unityHubPath, installPath, unityVersion, unityVersionChangeset,self_runner);
         if (unityModules.length > 0) {
             await installUnityModules(unityHubPath, unityVersion, unityModules, unityModulesChild);
         }
-        await postInstall();
+        await postInstall(self_runner);
 
         core.setOutput('unity-version', unityVersion);
         core.setOutput('unity-path', unityPath);
@@ -78,11 +83,11 @@ async function installUnityHub() {
     return unityHubPath;
 }
 
-async function installUnityEditor(unityHubPath, installPath, unityVersion, unityVersionChangeset) {
+async function installUnityEditor(unityHubPath, installPath, unityVersion, unityVersionChangeset,githubMachine) {
     let unityPath = await findUnity(unityHubPath, unityVersion);
     if (!unityPath) {
         if (installPath) {
-            if (process.platform === 'linux' || process.platform === 'darwin') {
+            if ((process.platform === 'linux' || process.platform === 'darwin') && !self_runner) {
                 await execute(`sudo mkdir -p "${installPath}"`);
                 await execute(`sudo chmod -R o+rwx "${installPath}"`);
             }
@@ -106,8 +111,8 @@ async function installUnityModules(unityHubPath, unityVersion, unityModules, uni
     }
 }
 
-async function postInstall() {
-    if (process.platform === 'darwin') {
+async function postInstall(self_runner) {
+    if (process.platform === 'darwin' && !self_runner) {
         await execute('sudo mkdir -p "/Library/Application Support/Unity"');
         await execute(`sudo chown -R ${process.env.USER} "/Library/Application Support/Unity"`);
     }

--- a/src/setup.js
+++ b/src/setup.js
@@ -120,6 +120,7 @@ async function findUnity(unityHubPath, unityVersion) {
     if (match) {
         unityPath = match[1];
     }
+    //2021.3.7f1 (Intel), installed at /Applications/Unity/Hub/Editor/2021.3.7f1/Unity.app
     const match_intel = output.match(new RegExp(`${unityVersion} (Intel), installed at (.+)`));
     if (match_intel) {
         unityPath = match_intel[1];


### PR DESCRIPTION
Unity Hub now output new installed versions like this on macOS:

2021.3.7f1 (Intel), installed at /Applications/Unity/Hub/Editor/2021.3.7f1/Unity.app

A better regex was necessary.
Also, sudo commands don't work on github self-runners, so I added a variable to skip them.

Hope this help the community.
(Updated with additional fixes)